### PR TITLE
Change default settings provider to have a base configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Debug tab, and adding the value to the Environment variables section.
 Example: `BaseTemplatePath` => `RazorEmail`
 
 ###Folder Structure###
-`<BaseTemplatePath>\TemplateName\TemplateName.json` contains the main settings file.
+`<BaseTemplatePath>\settings.json` contains the base configuration file (can be named something else `.json`)
+`<BaseTemplatePath>\TemplateName\TemplateName.json` contains the template override settings file (optional)
 
 `<BaseTemplatePath>\TemplateName\TemplateName.razor` contains a razor template to produce an HTML mail message content (optional)
 
@@ -33,9 +34,11 @@ Either the `.razor` file or the `.text` file must exist. You can also supply bot
 
 **Note: The name of the file is unimportant, there just needs to be only one `.json` file, `.razor` or `.text` file each!**
 
-###Template Configuration###
-Each template needs to have a configuration file that ends with `.json`. This configuration takes the format of the example below:
-```
+###Base Configuration###
+A `.json` file is required in `<BaseTemplatePath>` to serve as the master settings for all templates. The idea is that default settings are kept here, and templates will override them if needed. Settings like `subject` will usually be overridden, but settings like `server`, `username`, and `password` will usually be defined once.
+
+ This configuration takes the format of the example below:
+```json
 {
 	"from": "\"RazorEmailCore\" <donotreply@SomeDomain.com>",
 	"subject": "New User Created",
@@ -48,6 +51,11 @@ Each template needs to have a configuration file that ends with `.json`. This co
 }
 ```
 
+As with any credentials in a project, we recommend not committing them to your source control.
+
+###Template Configuration###
+
+Templates may override settings in the Base Configuration by adding their own `.json` file of the same format as the Base Configuration.
 
 ###Code###
 
@@ -108,11 +116,11 @@ It returns a `ConfigSettings` class that can be inherited and expanded.
 
 This class must provide:
  1. Either the `HtmlEmailTemplate` or the `PlainTextEmailTemplate` values
- 1. The `Subject` for the email
- 1. The `From` sender for the email
- 1. The `Server` in URI format (e.g. `smtp://smtp.sendgrid.net:587`)
- 1. Optional login information `Username` and `Password` for the SMTP server
- 1. Optional `Cc`, `Bcc` values
+ 2. The `Subject` for the email
+ 3. The `From` sender for the email
+ 4. The `Server` in URI format (e.g. `smtp://smtp.sendgrid.net:587`)
+ 5. Optional login information `Username` and `Password` for the SMTP server
+ 6. Optional `Cc`, `Bcc` values
 
 **Note: The default option for this class is the built-in `DefaultMessageSettingsProvider` class**
 

--- a/src/RazorEmailCore/ConfigSettings.cs
+++ b/src/RazorEmailCore/ConfigSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
@@ -27,5 +28,28 @@ namespace RazorEmailCore
 
 		public string PlainTextEmailTemplate { get; set; }
 		public string HtmlEmailTemplate { get; set; }
+
+		/// <summary>
+		/// Replaces any public string properties in the target with defined properties in the source
+		/// </summary>
+		/// <param name="source"></param>
+		/// <param name="target"></param>
+		public static void ReplacePublicStringProperties(ConfigSettings source, ConfigSettings target)
+		{
+			// loop over all public properties in ConfigSettings
+			foreach(PropertyInfo property in typeof(ConfigSettings).GetProperties())
+			{
+				// try to cast the property as a string
+				string sourceValue = property.GetValue(source) as string;
+			
+				// skip if the cast didn't work (null)
+				// or the string is null itself
+				if (string.IsNullOrWhiteSpace(sourceValue))
+					continue;
+
+				// replace the target's value with the source value
+				property.SetValue(target, sourceValue);
+			}
+		}
 	}
 }

--- a/src/RazorEmailCore/DefaultMessageSettingsProvider.cs
+++ b/src/RazorEmailCore/DefaultMessageSettingsProvider.cs
@@ -19,7 +19,8 @@ namespace RazorEmailCore
 
 		public ConfigSettings LoadByTemplateName(string templateName)
 		{
-			ConfigSettings result = null;
+			ConfigSettings baseSettings = null;
+			ConfigSettings templateSettings = null;
 
 			// Check to see if there is a directory with the template name
 			string dirpath = BasePath;
@@ -27,13 +28,15 @@ namespace RazorEmailCore
 				dirpath = Path.Combine(BasePath, templateName);
 
 			// Look for the correct files (.json, .razor, .text)
-			string jsonFile;
+			string baseSettingsFile;
+			string templateSettingsFile;
 			string razorFile;
 			string textFile;
 
 			try
 			{
-				jsonFile = Directory.EnumerateFiles(dirpath, "*.json").Single();
+				baseSettingsFile = Directory.EnumerateFiles(BasePath, "*.json").Single();
+				templateSettingsFile = Directory.EnumerateFiles(dirpath, "*.json").SingleOrDefault();
 				razorFile = Directory.EnumerateFiles(dirpath, "*.razor").SingleOrDefault();
 				textFile = Directory.EnumerateFiles(dirpath, "*.text").SingleOrDefault();
 			}
@@ -42,26 +45,39 @@ namespace RazorEmailCore
 				throw new RazorEmailCoreConfigurationException("One or more expected configuration files are missing or invalid (possibly duplicated).", ioex);
 			}
 
-			// Read the configuration in the json file
+			// Read the configuration in the json file for base and template (if it exists)
+			baseSettings = ParseSettings(baseSettingsFile);
+			if (!string.IsNullOrEmpty(templateSettingsFile))
+				templateSettings = ParseSettings(templateSettingsFile);
+
+			// if a template file exists, merge the two config files,
+			// with the template overriding settings in the base,
+			// if they're not already the same
+			if (templateSettings != null && !string.Equals(baseSettingsFile, templateSettingsFile))
+				ConfigSettings.ReplacePublicStringProperties(source: templateSettings, target: baseSettings);
+
+			// get the template text from the template files, if possible
+			if (!string.IsNullOrWhiteSpace(razorFile))
+				baseSettings.HtmlEmailTemplate = File.ReadAllText(razorFile);
+
+			if (!string.IsNullOrWhiteSpace(textFile))
+				baseSettings.PlainTextEmailTemplate = File.ReadAllText(textFile);
+
+			return baseSettings;
+		}
+
+		private static ConfigSettings ParseSettings(string jsonFile)
+		{
 			try
 			{
 				var serializer = new DataContractJsonSerializer(typeof(ConfigSettings));
 				using (var fs = File.OpenRead(jsonFile))
-					result = (ConfigSettings)serializer.ReadObject(fs);
+					return (ConfigSettings)serializer.ReadObject(fs);
 			}
 			catch (Exception ex)
 			{
 				throw new RazorEmailCoreConfigurationException($"Error reading configuration file: {jsonFile}", ex);
 			}
-
-			if (!string.IsNullOrWhiteSpace(razorFile))
-				result.HtmlEmailTemplate = File.ReadAllText(razorFile);
-
-			if (!string.IsNullOrWhiteSpace(textFile))
-				result.PlainTextEmailTemplate = File.ReadAllText(textFile);
-
-			return result;
 		}
-
 	}
 }


### PR DESCRIPTION
Changed DefaultMessageSettingsProvider to use a base configuration file, then look for a template configuration file that will override the settings in the base file.

Updated the documentation to reflect this change.